### PR TITLE
Fix NoMethodError stub

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'test/unit'
-require 'rr'
+require 'test/unit/rr'
 require 'test/unit/power_assert'
 require 'pry'
 require 'bigquery_migration'


### PR DESCRIPTION
It has caused a NoMethodError in my environment. So I fixed it.

BTW, this message also displayed in my environment.

```
test-unit-power_assert: warning: You don't need to require test-unit-power_assert.
test-unit-power_assert: warning: test-unit 3 or later has built-in support for power_assert.
```
