### PR TITLE
Support migrate_partitioned_table

### DIFF
--- a/example/migrate_partitioned_table.yml
+++ b/example/migrate_partitioned_table.yml
@@ -1,0 +1,23 @@
+bigquery: &bigquery
+  json_keyfile: example/your-project-000.json
+  dataset: your_dataset_name
+  table: your_table_name
+
+actions:
+- action: create_dataset
+  <<: *bigquery
+- action: migrate_partitioned_table
+  <<: *bigquery
+  columns:
+    - { name: 'timestamp', type: 'TIMESTAMP' }
+    - name: 'record'
+      type: 'RECORD'
+      fields:
+        - { name: 'string', type: 'STRING' }
+        - { name: 'integer', type: 'INTEGER' }
+        - { name: 'bytes', type: 'BYTES' }
+- action: migrate_partitioned_table
+  <<: *bigquery
+  schema_file: example/schema.json
+- action: delete_table
+  <<: *bigquery

--- a/lib/bigquery_migration/action.rb
+++ b/lib/bigquery_migration/action.rb
@@ -42,6 +42,7 @@ class BigqueryMigration
         insert_select
         copy_table
         table_info
+        migrate_partitioned_table
       ])
     end
 
@@ -74,6 +75,13 @@ class BigqueryMigration
         columns: config[:columns],
         backup_dataset: config[:backup_dataset],
         backup_table: config[:backup_table]
+      )
+    end
+
+    def migrate_partitioned_table
+      client.migrate_partitioned_table(
+        schema_file: config[:schema_file],
+        columns: config[:columns],
       )
     end
 

--- a/lib/bigquery_migration/schema.rb
+++ b/lib/bigquery_migration/schema.rb
@@ -70,7 +70,6 @@ class BigqueryMigration
       self.class.build_query_fields(source_columns, self)
     end
 
-
     class << self
       # The name must contain only letters (a-z, A-Z), numbers (0-9), or underscores (_),
       # and must start with a letter or underscore. The maximum length is 128 characters.
@@ -382,6 +381,17 @@ class BigqueryMigration
             #  We have to add columns with patch_table beforehand
           end
         end
+      end
+
+      def make_nullable!(columns)
+        columns.each do |column|
+          if column[:fields]
+            make_nullable!(column[:fields])
+          else
+            column[:mode] = 'NULLABLE'
+          end
+        end
+        columns
       end
     end
   end


### PR DESCRIPTION
migrate_partitioned_table basically behaves as:
- create_table with time_partitioning option
- patch_table
  - make nullable drop columns
  - add nullable columns
  - raise an error if type is changed (not supported)
