### PR TITLE
Fix generate_value record with empty hash

### DIFF
--- a/lib/bigquery_migration/table_data.rb
+++ b/lib/bigquery_migration/table_data.rb
@@ -65,8 +65,7 @@ class BigqueryMigration
     private def generate_value(columns: nil, rows: nil, count: nil)
       logger.info { "generate_value(columns: #{columns}, rows: #{rows}, count: #{count})" }
       value = []
-      return value if rows.nil?
-      return [nil] if rows.empty?
+      return [nil] if (rows.nil? || rows.empty?)
       validate_rows!(rows)
       rows[:f].zip(columns).each do |row, column|
         if column[:type] == 'RECORD'

--- a/lib/bigquery_migration/table_data.rb
+++ b/lib/bigquery_migration/table_data.rb
@@ -33,7 +33,7 @@ class BigqueryMigration
     # So, rows must be a hash and hash has key f:.
     private def calculate_repeated_count(columns: nil, rows: nil)
       logger.info { "calculate_repeated_count(columns: #{columns}, rows: #{rows})" }
-      return [1] if rows.nil?
+      return [1] if (rows.nil? || rows.empty?)
       validate_rows!(rows)
       rows[:f].zip(columns).map do |row, column|
         if column[:type] == 'RECORD'
@@ -66,6 +66,7 @@ class BigqueryMigration
       logger.info { "generate_value(columns: #{columns}, rows: #{rows}, count: #{count})" }
       value = []
       return value if rows.nil?
+      return [nil] if rows.empty?
       validate_rows!(rows)
       rows[:f].zip(columns).each do |row, column|
         if column[:type] == 'RECORD'

--- a/test/test_table_data.rb
+++ b/test/test_table_data.rb
@@ -484,6 +484,63 @@ class BigqueryMigration
 
         assert { TableData.new(columns, rows).generate_values == expected }
       end
+
+      def test_generate_values_record_with_empty_hash
+        columns = [
+          { name: "test", type: "STRING" },
+          { name: "record1", type: "RECORD", fields: [
+            { name: "child", type: "STRING" },
+          ] },
+          { name: "record2", type: "RECORD", fields: [
+            { name: "child", type: "STRING" }
+          ] },
+          { name: "record3", type: "RECORD", mode: "REPEATED", fields: [
+            { name: "array", type: "INTEGER", mode: "REPEATED" }
+          ] },
+          { name: "date", type: "STRING" },
+          { name: "timestamp", type: "TIMESTAMP" }
+          ]
+
+        rows = [
+          { f: [
+            { v: 'fuga' },
+            { v:
+              { f: [
+                { v: 'hoge' },
+              ] }
+            },
+            { v: {} },
+
+            { v: [
+              { v:
+                { f: [
+                  { v: [
+                    { v: '1' }
+                    ] }
+                ] }
+              },
+              { v:
+                { f: [
+                  { v: [
+                    { v: '4' }
+                  ] }
+                ] }
+              }
+            ] },
+            { v: '2016-10-17' },
+            { v: '1.47663E9' }
+          ] }
+        ]
+
+        expected = [
+          [
+            ["fuga", "hoge", nil, "1", "2016-10-17", "1.47663E9"],
+            [nil, nil, nil, "4", nil, nil]
+          ]
+        ]
+
+        assert { TableData.new(columns, rows).generate_values == expected }
+      end
     end
   end
 end


### PR DESCRIPTION
Now It raises a error at generate_value if row is empty hash.
So fixed it.
