### PR TITLE
Fix configure test part in test_bigquery_wrapper.rb

### DIFF
--- a/lib/bigquery_migration/bigquery_wrapper.rb
+++ b/lib/bigquery_migration/bigquery_wrapper.rb
@@ -729,7 +729,14 @@ class BigqueryMigration
           when String
             return HashUtil.deep_symbolize_keys(JSON.parse(File.read(json_keyfile)))
           when Hash
-            return json_keyfile[:content]
+            case json_keyfile[:content]
+            when String
+              return HashUtil.deep_symbolize_keys(JSON.parse(json_keyfile[:content]))
+            when Hash
+              return json_keyfile[:content]
+            else
+              raise ConfigError.new "Unsupported json_keyfile type"
+            end
           else
             raise ConfigError.new "Unsupported json_keyfile type"
           end

--- a/test/test_bigquery_wrapper.rb
+++ b/test/test_bigquery_wrapper.rb
@@ -32,6 +32,21 @@ else
           assert_nothing_raised { instance.client }
         end
 
+        def test_configure_json_keyfile_content_json
+          config = {
+            'json_keyfile' => {
+              'content' => File.read(JSON_KEYFILE),
+            },
+            'dataset'      => 'bigquery_migration_unittest',
+            'table'        => 'test',
+          }
+          instance = BigqueryWrapper.new(config)
+          assert_nothing_raised { instance.project }
+          assert_nothing_raised { instance.dataset }
+          assert_nothing_raised { instance.table }
+          assert_nothing_raised { instance.client }
+        end
+
         def test_configure_json_keyfile_content_hash
           config = {
             'json_keyfile' => {

--- a/test/test_bigquery_wrapper.rb
+++ b/test/test_bigquery_wrapper.rb
@@ -25,6 +25,7 @@ else
             'dataset'      => 'bigquery_migration_unittest',
             'table'        => 'test',
           }
+          instance = BigqueryWrapper.new(config)
           assert_nothing_raised { instance.project }
           assert_nothing_raised { instance.dataset }
           assert_nothing_raised { instance.table }

--- a/test/test_bigquery_wrapper.rb
+++ b/test/test_bigquery_wrapper.rb
@@ -32,20 +32,6 @@ else
           assert_nothing_raised { instance.client }
         end
 
-        def test_configure_json_keyfile_content_json
-          config = {
-            'json_keyfile' => {
-              'content' => File.read(JSON_KEYFILE),
-            },
-            'dataset'      => 'bigquery_migration_unittest',
-            'table'        => 'test',
-          }
-          assert_nothing_raised { instance.project }
-          assert_nothing_raised { instance.dataset }
-          assert_nothing_raised { instance.table }
-          assert_nothing_raised { instance.client }
-        end
-
         def test_configure_json_keyfile_content_hash
           config = {
             'json_keyfile' => {


### PR DESCRIPTION
This PR fixes the following two things.

(1). In test of `test_configure_json_keyfile`, uses an `instance` which config has not been applied.
(2).`test_configure_content_json` is incorrect, It seems to me that BigQueryWrapper class  can not accept JSON_KEYFILE as string of json.

About (2), I think that test is unnecessary because the feature does not exist. 
When JSON_KEYFILE is string, only file paths is accepted.
- https://github.com/medjed/bigquery_migration/blob/ab05ed574ee1a2d7a476630d46de9c3b9b8d9d6f/lib/bigquery_migration/bigquery_wrapper.rb#L729-L730