### PR TITLE
Remove power-assert gem

### DIFF
--- a/bigquery_migration.gemspec
+++ b/bigquery_migration.gemspec
@@ -29,5 +29,4 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "test-unit"
   spec.add_development_dependency "test-unit-rr"
-  spec.add_development_dependency "test-unit-power_assert"
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -2,7 +2,6 @@
 
 require 'test/unit'
 require 'test/unit/rr'
-require 'test/unit/power_assert'
 require 'pry'
 require 'bigquery_migration'
 


### PR DESCRIPTION
It is now built-in by test-unit.

```
$ bundle exec rake test

test-unit-power_assert: warning: You don't need to require test-unit-power_assert.
test-unit-power_assert: warning: test-unit 3 or later has built-in support for power_assert.
```