### PR TITLE
Added time_partitioning.field parameter to action `migrate_partitioned_table`

### DIFF
--- a/example/migrate_partitioned_table.yml
+++ b/example/migrate_partitioned_table.yml
@@ -19,5 +19,8 @@ actions:
 - action: migrate_partitioned_table
   <<: *bigquery
   schema_file: example/schema.json
+  options:
+    time_partitioning:
+      field: timestamp
 - action: delete_table
   <<: *bigquery

--- a/lib/bigquery_migration/bigquery_wrapper.rb
+++ b/lib/bigquery_migration/bigquery_wrapper.rb
@@ -188,6 +188,7 @@ class BigqueryMigration
           body[:time_partitioning] = {
             type: options['time_partitioning']['type'],
             expiration_ms: options['time_partitioning']['expiration_ms'],
+            field: options['time_partitioning']['field'],
           }
         end
 
@@ -217,7 +218,8 @@ class BigqueryMigration
     alias :create_table :insert_table
 
     def insert_partitioned_table(dataset: nil, table: nil, columns:, options: {})
-      options['time_partitioning'] = {'type'=>'DAY'}
+      options['time_partitioning'] ||= {}
+      options['time_partitioning']['type'] = 'DAY'
       insert_table(dataset: dataset, table: table, columns: columns, options: options)
     end
     alias :create_partitioned_table :insert_partitioned_table


### PR DESCRIPTION
And fixed time_partitioning option that is currently not working.

Refs:
https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#TimePartitioning
https://www.rubydoc.info/github/google/google-api-ruby-client/Google/Apis/BigqueryV2/TimePartitioning